### PR TITLE
Allow sparse indexes to be saved and loaded from file 

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -24,9 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip' 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flake8
         args: [--max-line-length=88, --ignore=E203]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.14.1
     hooks:
     -   id: mypy
         args: [--strict, --ignore-missing-imports]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 TODO:
+-- WAL for LSM tree 
 -- Implement bloom filter in lsm index to speed up reads where key is not in db
 -- Currently only implemenet clustered index... maybe add in non clustered
 -- Multi column indexes

--- a/src/sandb/config.py
+++ b/src/sandb/config.py
@@ -1,5 +1,17 @@
 from pathlib import Path
+from typing import Literal, Mapping, Union, get_args
 
 CURRENT_DIR = Path(__file__).absolute()
 ROOT_FOLDER = "sandb"
 ROOT_DIR = next(p for p in CURRENT_DIR.parents if p.parts[-1] == ROOT_FOLDER)
+
+
+VALID_DTYPE = Union[str, int]
+VALID_DTYPE_ALIAS = Literal[0, 1]
+
+VALID_DTYPE_MAPPING: Mapping[VALID_DTYPE, VALID_DTYPE_ALIAS] = dict(
+    zip(get_args(VALID_DTYPE), get_args(VALID_DTYPE_ALIAS))
+)
+REVERSE_DTYPE_MAPPING: Mapping[VALID_DTYPE_ALIAS, VALID_DTYPE] = {
+    v: k for k, v in VALID_DTYPE_MAPPING.items()
+}

--- a/src/sandb/indexes/abc.py
+++ b/src/sandb/indexes/abc.py
@@ -1,19 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Any, Protocol
+from typing import Any
 
-
-class Comparable(Protocol):
-    """Protocol for annotating comparable types."""
-
-    def __lt__(self, other: Any, /) -> bool:
-        ...
+from sandb.config import VALID_DTYPE
 
 
 class Index(ABC):
     @abstractmethod
-    def read(self, key: Comparable) -> str | None:
+    def read(self, key: VALID_DTYPE) -> str | None:
         ...
 
     @abstractmethod
-    def write(self, key: Comparable, value: Any) -> None:
+    def write(self, key: VALID_DTYPE, value: Any) -> None:
         ...

--- a/src/sandb/indexes/lsm_tree.py
+++ b/src/sandb/indexes/lsm_tree.py
@@ -6,7 +6,6 @@ from typing import Any, Tuple, TypeVar
 from numpy import inf
 from sortedcontainers import SortedDict
 
-from sandb.config import ROOT_DIR
 from sandb.indexes.abc import Comparable, Index
 
 T = TypeVar("T")
@@ -14,7 +13,10 @@ T = TypeVar("T")
 
 class LSMTree(Index):
     def __init__(
-        self, memtable_max_size: int = 1000, segment_chunk_size_for_indexing: int = 100
+        self,
+        segment_folder_path: Path,
+        memtable_max_size: int = 1000,
+        segment_chunk_size_for_indexing: int = 100,
     ):
         self.memtable: SortedDict[Comparable, Any] = SortedDict()
         self.memtable_max_size = memtable_max_size
@@ -27,7 +29,7 @@ class LSMTree(Index):
 
         self.segment_index = 0
 
-        self.segment_folder_path = ROOT_DIR / "lsm_segments"
+        self.segment_folder_path = segment_folder_path
         self.segment_folder_path.mkdir(exist_ok=True)
 
     def read(self, key: Comparable) -> str | None:
@@ -112,7 +114,13 @@ class LSMTree(Index):
         q: 300
         z: 400}
         then the boundaries if we try and find key j would be a and h.
+
+        Returns:
+            tuple[int, int | None] where the first element is the start of the area to
+            search on file for our value and the second element is the end, or
+            None if key might be in the last segment.
         """
+        # TODO: update this to use binary search
         floor = 0
         ceil = None
         prev_value = 0
@@ -131,6 +139,31 @@ class LSMTree(Index):
             floor = value
 
         return floor, ceil
+
+
+def save_index_to_file(folder_path: Path, index: SortedDict[Comparable, int]) -> None:
+    """
+    Saves our indexes which are used to efficiently scan our segments to file.
+    Currently just uses a simple txt format where each item in the index is stored
+    as a str like 'key':'value'. It will then append a newline character so that
+    we can determine when one index is finished and the next begins. Currently relies
+    on the order the indexes are saved to disk which correspond to the order of the
+    segment files.
+
+    Args:
+        index (SortedDict[Comparable, int]): index to save to file
+    """
+
+    filepath = folder_path / "index.txt"
+
+    if not filepath.exists():
+        filepath.touch()
+
+    with open(filepath, "a") as f:
+        for key, value in index.items():
+            f.write(str(key) + ":" + str(value))
+
+        f.write("\n")
 
 
 def merge_segment_files(

--- a/src/sandb/indexes/lsm_tree.py
+++ b/src/sandb/indexes/lsm_tree.py
@@ -18,25 +18,21 @@ class LSMTree(Index):
     def __init__(self, lsmtree_metadata: LSMTreeMetadata):
         self.memtable: dict[VALID_DTYPE, Any] = SortedDict()
 
-        self.lsmtree_metadata = lsmtree_metadata
-
-        self.metadata_file_path = lsmtree_metadata.folder_path / "metadata.json"
-        self.segment_folder_path = lsmtree_metadata.folder_path / "segments"
-        self.indexes_file_path = lsmtree_metadata.folder_path / "index.txt"
+        self.metadata = lsmtree_metadata
 
         # This is the SStable storage. First value is file path, second value is the
         # sparse index for the SStable. This is ordered such that we can look through
         # newest to oldest segments.
         self.indexes: OrderedDict[Path, dict[VALID_DTYPE, int]]
 
-        if self.metadata_file_path.exists():
+        if self.metadata.metadata_file_path.exists():
             self.indexes = self._load_indexes_from_file()
 
         else:
-            with open(self.metadata_file_path, "w") as f:
-                json.dump(lsmtree_metadata.model_dump_json(), f)
+            with open(self.metadata.metadata_file_path, "w") as f:
+                json.dump(self.metadata.model_dump_json(), f)
             self.indexes = OrderedDict()
-            self.segment_folder_path.mkdir()
+            self.metadata.segment_folder_path.mkdir()
 
         self.segment_index = len(self.indexes)
 
@@ -66,13 +62,13 @@ class LSMTree(Index):
         return value
 
     def write(self, key: VALID_DTYPE, value: Any) -> None:
-        if len(self.memtable) >= self.lsmtree_metadata.memtable_max_size:
+        if len(self.memtable) >= self.metadata.memtable_max_size:
             self._flush_memtable_to_disk()
         self.memtable.update({key: value})
 
     def _load_indexes_from_file(self) -> OrderedDict[Path, dict[VALID_DTYPE, int]]:
-        number_of_segments = len(glob(str(self.segment_folder_path / "*")))
-        with open(self.indexes_file_path, "r") as f:
+        number_of_segments = len(glob(str(self.metadata.segment_folder_path / "*")))
+        with open(self.metadata.index_file_path, "r") as f:
             indexes = f.read()
 
         individual_indexes = indexes.split("\n\n")[:-1]
@@ -89,7 +85,7 @@ class LSMTree(Index):
             serialised_indexes.append(
                 SortedDict(
                     {
-                        self.lsmtree_metadata.primary_key.dtype(row.split(":")[0]): int(
+                        self.metadata.primary_key.dtype(row.split(":")[0]): int(
                             row.split(":")[1]
                         )
                         for row in index
@@ -100,7 +96,7 @@ class LSMTree(Index):
         return OrderedDict(
             zip(
                 [
-                    self.segment_folder_path / f"segment_{ind}.txt"
+                    self.metadata.segment_folder_path / f"segment_{ind}.txt"
                     for ind in range(number_of_segments)
                 ],
                 serialised_indexes,
@@ -126,9 +122,9 @@ class LSMTree(Index):
         return value
 
     def _flush_memtable_to_disk(self) -> None:
-        index_counter = self.lsmtree_metadata.segment_chunk_size_for_indexing
+        index_counter = self.metadata.segment_chunk_size_for_indexing
         segment_file_path = (
-            self.segment_folder_path / f"segment_{self.segment_index}.txt"
+            self.metadata.segment_folder_path / f"segment_{self.segment_index}.txt"
         )
         index: dict[VALID_DTYPE, int] = SortedDict()
 
@@ -137,9 +133,7 @@ class LSMTree(Index):
                 if index_counter == 0:
                     offset = f.tell()
                     index.update({key: offset})
-                    index_counter = (
-                        self.lsmtree_metadata.segment_chunk_size_for_indexing
-                    )
+                    index_counter = self.metadata.segment_chunk_size_for_indexing
 
                 f.write(f"{key}: {value}\n")
                 index_counter -= 1

--- a/src/sandb/indexes/lsm_tree.py
+++ b/src/sandb/indexes/lsm_tree.py
@@ -161,7 +161,7 @@ def save_index_to_file(folder_path: Path, index: SortedDict[Comparable, int]) ->
 
     with open(filepath, "a") as f:
         for key, value in index.items():
-            f.write(str(key) + ":" + str(value))
+            f.write(str(key) + ":" + str(value) + "\n")
 
         f.write("\n")
 

--- a/src/sandb/indexes/lsm_tree.py
+++ b/src/sandb/indexes/lsm_tree.py
@@ -4,35 +4,33 @@ from collections import OrderedDict
 from glob import glob
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, Tuple, TypeVar
+from typing import Any, Tuple
 
 from numpy import inf
 from sortedcontainers import SortedDict
 
-from sandb.indexes.abc import Comparable, Index
-from sandb.tables.metadata import VALID_DTYPE, LSMTreeMetadata
-
-T = TypeVar("T")
+from sandb.config import VALID_DTYPE
+from sandb.indexes.abc import Index
+from sandb.tables.metadata import LSMTreeMetadata
 
 
 class LSMTree(Index):
     def __init__(self, lsmtree_metadata: LSMTreeMetadata):
-        self.memtable: SortedDict[Comparable, Any] = SortedDict()
+        self.memtable: dict[VALID_DTYPE, Any] = SortedDict()
+
         self.lsmtree_metadata = lsmtree_metadata
 
-        self.metadata_file_path = lsmtree_metadata.folder_path / "metadata.txt"
+        self.metadata_file_path = lsmtree_metadata.folder_path / "metadata.json"
         self.segment_folder_path = lsmtree_metadata.folder_path / "segments"
-        self.indexes_file_path = lsmtree_metadata.folder_path / "indexes.txt"
-
-        self.primary_key = self.lsmtree_metadata.primary_key
+        self.indexes_file_path = lsmtree_metadata.folder_path / "index.txt"
 
         # This is the SStable storage. First value is file path, second value is the
         # sparse index for the SStable. This is ordered such that we can look through
         # newest to oldest segments.
-        self.indexes: OrderedDict[Path, SortedDict[VALID_DTYPE, int]]
+        self.indexes: OrderedDict[Path, dict[VALID_DTYPE, int]]
 
         if self.metadata_file_path.exists():
-            self.indexes = self.load_indexes_from_file()
+            self.indexes = self._load_indexes_from_file()
 
         else:
             with open(self.metadata_file_path, "w") as f:
@@ -42,44 +40,7 @@ class LSMTree(Index):
 
         self.segment_index = len(self.indexes)
 
-    def load_indexes_from_file(self) -> OrderedDict[Path, SortedDict[VALID_DTYPE, int]]:
-        number_of_segments = len(glob(str(self.segment_folder_path / "*")))
-        with open(self.indexes_file_path, "r") as f:
-            indexes = f.read()
-
-        individual_indexes = indexes.split("\n\n")
-
-        if number_of_segments != len(individual_indexes):
-            raise Exception(
-                "We have an incompatible number of indexes to segment files"
-            )
-
-        split_indexes = [index.split("\n") for index in individual_indexes]
-
-        serialised_indexes: list[SortedDict[VALID_DTYPE, int]] = []
-        for index in split_indexes:
-            serialised_indexes.append(
-                SortedDict(
-                    {
-                        self.primary_key.dtype(row.split(":")[0]): int(
-                            row.split(":")[1]
-                        )
-                        for row in index
-                    }
-                )
-            )
-
-        return OrderedDict(
-            zip(
-                [
-                    self.segment_folder_path / f"segment_{ind}.txt"
-                    for ind in range(number_of_segments)
-                ],
-                serialised_indexes,
-            )
-        )
-
-    def read(self, key: Comparable) -> str | None:
+    def read(self, key: VALID_DTYPE) -> str | None:
         """
         First try and read from the in-memory memtable.
         If the key does not exist in there
@@ -100,14 +61,56 @@ class LSMTree(Index):
         except KeyError:
             logging.info(f"key: {key} not in in memory memtable")
 
-        value = self.search_segments_on_disk(key)
+        value = self._search_segments_on_disk(key)
 
         return value
 
-    def search_segments_on_disk(self, key: Comparable) -> str | None:
+    def write(self, key: VALID_DTYPE, value: Any) -> None:
+        if len(self.memtable) >= self.lsmtree_metadata.memtable_max_size:
+            self._flush_memtable_to_disk()
+        self.memtable.update({key: value})
+
+    def _load_indexes_from_file(self) -> OrderedDict[Path, dict[VALID_DTYPE, int]]:
+        number_of_segments = len(glob(str(self.segment_folder_path / "*")))
+        with open(self.indexes_file_path, "r") as f:
+            indexes = f.read()
+
+        individual_indexes = indexes.split("\n\n")[:-1]
+
+        if number_of_segments != len(individual_indexes):
+            raise Exception(
+                "We have an incompatible number of indexes to segment files"
+            )
+
+        split_indexes = [index.split("\n") for index in individual_indexes]
+
+        serialised_indexes: list[dict[VALID_DTYPE, int]] = []
+        for index in split_indexes:
+            serialised_indexes.append(
+                SortedDict(
+                    {
+                        self.lsmtree_metadata.primary_key.dtype(row.split(":")[0]): int(
+                            row.split(":")[1]
+                        )
+                        for row in index
+                    }
+                )
+            )
+
+        return OrderedDict(
+            zip(
+                [
+                    self.segment_folder_path / f"segment_{ind}.txt"
+                    for ind in range(number_of_segments)
+                ],
+                serialised_indexes,
+            )
+        )
+
+    def _search_segments_on_disk(self, key: VALID_DTYPE) -> str | None:
         value = ""
         for filepath, index in self.indexes.items():
-            floor_offset, ceil_offset = self.get_floor_ceil_of_key_in_index(key, index)
+            floor_offset, ceil_offset = self._get_floor_ceil_of_key_in_index(key, index)
             with open(filepath, "r") as current_segment:
                 current_segment.seek(floor_offset)
                 curr_offset = floor_offset
@@ -122,17 +125,12 @@ class LSMTree(Index):
 
         return value
 
-    def write(self, key: Comparable, value: Any) -> None:
-        if len(self.memtable) >= self.lsmtree_metadata.memtable_max_size:
-            self.flush_memtable_to_disk()
-        self.memtable.update({key: value})
-
-    def flush_memtable_to_disk(self) -> None:
+    def _flush_memtable_to_disk(self) -> None:
         index_counter = self.lsmtree_metadata.segment_chunk_size_for_indexing
         segment_file_path = (
             self.segment_folder_path / f"segment_{self.segment_index}.txt"
         )
-        index: SortedDict[Comparable, int] = SortedDict()
+        index: dict[VALID_DTYPE, int] = SortedDict()
 
         with open(segment_file_path, "a") as f:
             for key, value in self.memtable.items():
@@ -150,8 +148,8 @@ class LSMTree(Index):
         self.indexes.update({segment_file_path: index})
         self.segment_index += 1
 
-    def get_floor_ceil_of_key_in_index(
-        self, inputted_key: Comparable, index: SortedDict[Comparable, int]
+    def _get_floor_ceil_of_key_in_index(
+        self, inputted_key: VALID_DTYPE, index: dict[VALID_DTYPE, int]
     ) -> Tuple[int, int | None]:
         """
         Not very performant algorithm for looping through our SortedDict index
@@ -176,9 +174,11 @@ class LSMTree(Index):
         value = 0
         for key, value in index.items():
             value = int(value)
-            if key == inputted_key:
+            if type(inputted_key) is not type(key):
+                raise ValueError(f"Type mismatch: {type(inputted_key)} != {type(key)}")
+            elif key == inputted_key:
                 return (value, value)
-            elif inputted_key < key:
+            elif inputted_key < key:  # type: ignore
                 floor, ceil = prev_value, value
                 break
             prev_value = value
@@ -190,7 +190,7 @@ class LSMTree(Index):
         return floor, ceil
 
 
-def save_index_to_file(folder_path: Path, index: SortedDict[Comparable, int]) -> None:
+def save_index_to_file(folder_path: Path, index: dict[VALID_DTYPE, int]) -> None:
     """
     Saves our indexes which are used to efficiently scan our segments on file.
     Currently just uses a simple txt format where each item in the index is stored
@@ -200,7 +200,7 @@ def save_index_to_file(folder_path: Path, index: SortedDict[Comparable, int]) ->
     segment files.
 
     Args:
-        index (SortedDict[Comparable, int]): index to save to file
+        index (dict[VALID_DTYPE, int]): index to save to file
     """
 
     filepath = folder_path / "index.txt"
@@ -249,7 +249,7 @@ def merge_segment_files(
 
                 # TODO: This will only work with integer keys
                 min_value_index = keys.index(
-                    min(keys, key=lambda x: inf if x == "" else x)  # type: ignore
+                    min(keys, key=lambda x: inf if x == "" else x)
                 )
                 key = keys[min_value_index]
 

--- a/src/sandb/indexes/lsm_tree.py
+++ b/src/sandb/indexes/lsm_tree.py
@@ -1,5 +1,8 @@
+import json
 import logging
 from collections import OrderedDict
+from glob import glob
+from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Tuple, TypeVar
 
@@ -7,30 +10,74 @@ from numpy import inf
 from sortedcontainers import SortedDict
 
 from sandb.indexes.abc import Comparable, Index
+from sandb.tables.metadata import VALID_DTYPE, LSMTreeMetadata
 
 T = TypeVar("T")
 
 
 class LSMTree(Index):
-    def __init__(
-        self,
-        segment_folder_path: Path,
-        memtable_max_size: int = 1000,
-        segment_chunk_size_for_indexing: int = 100,
-    ):
+    def __init__(self, lsmtree_metadata: LSMTreeMetadata):
         self.memtable: SortedDict[Comparable, Any] = SortedDict()
-        self.memtable_max_size = memtable_max_size
+        self.lsmtree_metadata = lsmtree_metadata
 
-        self.segment_chunk_size_for_indexing = segment_chunk_size_for_indexing
+        self.metadata_file_path = lsmtree_metadata.folder_path / "metadata.txt"
+        self.segment_folder_path = lsmtree_metadata.folder_path / "segments"
+        self.indexes_file_path = lsmtree_metadata.folder_path / "indexes.txt"
+
+        self.primary_key = self.lsmtree_metadata.primary_key
+
         # This is the SStable storage. First value is file path, second value is the
         # sparse index for the SStable. This is ordered such that we can look through
         # newest to oldest segments.
-        self.segments: OrderedDict[Path, SortedDict[Comparable, Any]] = OrderedDict()
+        self.indexes: OrderedDict[Path, SortedDict[VALID_DTYPE, int]]
 
-        self.segment_index = 0
+        if self.metadata_file_path.exists():
+            self.indexes = self.load_indexes_from_file()
 
-        self.segment_folder_path = segment_folder_path
-        self.segment_folder_path.mkdir(exist_ok=True)
+        else:
+            with open(self.metadata_file_path, "w") as f:
+                json.dump(lsmtree_metadata.model_dump_json(), f)
+            self.indexes = OrderedDict()
+            self.segment_folder_path.mkdir()
+
+        self.segment_index = len(self.indexes)
+
+    def load_indexes_from_file(self) -> OrderedDict[Path, SortedDict[VALID_DTYPE, int]]:
+        number_of_segments = len(glob(str(self.segment_folder_path / "*")))
+        with open(self.indexes_file_path, "r") as f:
+            indexes = f.read()
+
+        individual_indexes = indexes.split("\n\n")
+
+        if number_of_segments != len(individual_indexes):
+            raise Exception(
+                "We have an incompatible number of indexes to segment files"
+            )
+
+        split_indexes = [index.split("\n") for index in individual_indexes]
+
+        serialised_indexes: list[SortedDict[VALID_DTYPE, int]] = []
+        for index in split_indexes:
+            serialised_indexes.append(
+                SortedDict(
+                    {
+                        self.primary_key.dtype(row.split(":")[0]): int(
+                            row.split(":")[1]
+                        )
+                        for row in index
+                    }
+                )
+            )
+
+        return OrderedDict(
+            zip(
+                [
+                    self.segment_folder_path / f"segment_{ind}.txt"
+                    for ind in range(number_of_segments)
+                ],
+                serialised_indexes,
+            )
+        )
 
     def read(self, key: Comparable) -> str | None:
         """
@@ -59,7 +106,7 @@ class LSMTree(Index):
 
     def search_segments_on_disk(self, key: Comparable) -> str | None:
         value = ""
-        for filepath, index in self.segments.items():
+        for filepath, index in self.indexes.items():
             floor_offset, ceil_offset = self.get_floor_ceil_of_key_in_index(key, index)
             with open(filepath, "r") as current_segment:
                 current_segment.seek(floor_offset)
@@ -76,29 +123,31 @@ class LSMTree(Index):
         return value
 
     def write(self, key: Comparable, value: Any) -> None:
-        if len(self.memtable) >= self.memtable_max_size:
+        if len(self.memtable) >= self.lsmtree_metadata.memtable_max_size:
             self.flush_memtable_to_disk()
         self.memtable.update({key: value})
 
     def flush_memtable_to_disk(self) -> None:
-        index_counter = self.segment_chunk_size_for_indexing
-        segment_file_name = (
+        index_counter = self.lsmtree_metadata.segment_chunk_size_for_indexing
+        segment_file_path = (
             self.segment_folder_path / f"segment_{self.segment_index}.txt"
         )
         index: SortedDict[Comparable, int] = SortedDict()
 
-        with open(segment_file_name, "a") as f:
+        with open(segment_file_path, "a") as f:
             for key, value in self.memtable.items():
                 if index_counter == 0:
                     offset = f.tell()
                     index.update({key: offset})
-                    index_counter = self.segment_chunk_size_for_indexing
+                    index_counter = (
+                        self.lsmtree_metadata.segment_chunk_size_for_indexing
+                    )
 
                 f.write(f"{key}: {value}\n")
                 index_counter -= 1
 
         self.memtable = SortedDict()
-        self.segments.update({segment_file_name: index})
+        self.indexes.update({segment_file_path: index})
         self.segment_index += 1
 
     def get_floor_ceil_of_key_in_index(
@@ -143,7 +192,7 @@ class LSMTree(Index):
 
 def save_index_to_file(folder_path: Path, index: SortedDict[Comparable, int]) -> None:
     """
-    Saves our indexes which are used to efficiently scan our segments to file.
+    Saves our indexes which are used to efficiently scan our segments on file.
     Currently just uses a simple txt format where each item in the index is stored
     as a str like 'key':'value'. It will then append a newline character so that
     we can determine when one index is finished and the next begins. Currently relies
@@ -185,7 +234,9 @@ def merge_segment_files(
             )
         return int(key_value[0]), key_value[1]
 
-    segment_files = []  # Initialising to avoid possible unbound errors in finally block
+    segment_files: list[
+        TextIOWrapper
+    ] = []  # Initialising to avoid possible unbound errors in finally block
     with open(merged_file_path, "a") as output_file:
         try:
             segment_files = [file.open("r") for file in segment_file_paths]

--- a/src/sandb/tables/metadata.py
+++ b/src/sandb/tables/metadata.py
@@ -68,3 +68,10 @@ class TableMetadata(BaseModel):
 
     def data_path(self) -> Path:
         return self.location / self.name / "data.csv"
+
+
+class LSMTreeMetadata(BaseModel):
+    folder_path: Path
+    memtable_max_size: int
+    segment_chunk_size_for_indexing: int
+    primary_key: Column

--- a/src/sandb/tables/metadata.py
+++ b/src/sandb/tables/metadata.py
@@ -1,21 +1,12 @@
+import json
 from functools import cached_property
 from pathlib import Path
-from typing import Literal, Mapping, Type, Union, get_args
+from typing import Type
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
+from sandb.config import VALID_DTYPE, VALID_DTYPE_ALIAS, VALID_DTYPE_MAPPING
 from sandb.indexes.abc import Index
-
-VALID_DTYPE_ALIAS = Literal[0, 1]
-VALID_DTYPE = Union[str, int]
-
-VALID_DTYPE_MAPPING: Mapping[VALID_DTYPE, VALID_DTYPE_ALIAS] = dict(
-    zip(get_args(VALID_DTYPE), get_args(VALID_DTYPE_ALIAS))
-)
-
-REVERSE_DTYPE_MAPPING: Mapping[VALID_DTYPE_ALIAS, VALID_DTYPE] = {
-    v: k for k, v in VALID_DTYPE_MAPPING.items()
-}
 
 
 class Column(BaseModel):
@@ -75,3 +66,8 @@ class LSMTreeMetadata(BaseModel):
     memtable_max_size: int
     segment_chunk_size_for_indexing: int
     primary_key: Column
+
+    @classmethod
+    def load_from_file(cls, folder_path: Path) -> "LSMTreeMetadata":
+        with open(folder_path / "metadata.json", "r") as f:
+            return cls.model_validate_json(json.load(f))

--- a/src/sandb/tables/metadata.py
+++ b/src/sandb/tables/metadata.py
@@ -71,3 +71,15 @@ class LSMTreeMetadata(BaseModel):
     def load_from_file(cls, folder_path: Path) -> "LSMTreeMetadata":
         with open(folder_path / "metadata.json", "r") as f:
             return cls.model_validate_json(json.load(f))
+
+    @property
+    def metadata_file_path(self) -> Path:
+        return self.folder_path / "metadata.json"
+
+    @property
+    def segment_folder_path(self) -> Path:
+        return self.folder_path / "segments"
+
+    @property
+    def index_file_path(self) -> Path:
+        return self.folder_path / "index.txt"

--- a/src/sandb/tables/table.py
+++ b/src/sandb/tables/table.py
@@ -106,7 +106,7 @@ def read(
 
     Args:
         column_to_query (str): Column to check
-        predicate (Any): value to check column gainst
+        predicate (Any): value to check column against
         table (TableMetadata): table to scan
 
     Returns:

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -81,7 +81,6 @@ def test_read_from_db() -> None:
                 primary_key=Column(name="col_1", dtype=int),
             ),
         )
-        lsmtree.segment_folder_path = Path(tmp)
         for num in LIST_OF_NUMS:
             lsmtree.write(num, num2words(num))
 

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -207,9 +207,7 @@ def test_write_to_db() -> None:
         for num in LONGER_LIST_OF_NUMS:
             lsmtree.write(num, num2words(num))
 
-        print(os.listdir(tmp))
-
-        assert os.listdir(Path(tmp) / "segments") == [
+        assert sorted(os.listdir(Path(tmp) / "segments")) == [
             "segment_0.txt",
             "segment_1.txt",
             "segment_2.txt",
@@ -252,7 +250,7 @@ def test_write_to_db() -> None:
             ],
         ),
         (
-            [[1, 2, 3], []],
+            [[1, 2, 3], []],  # type: ignore
             [
                 "1: one_1\n",
                 "2: two_1\n",

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -31,7 +31,7 @@ def test_get_floor_ceil_of_key_in_index(
     expected_output: tuple[int, int | None],
     test_tree: SortedDict[Comparable, int],
 ) -> None:
-    lsm = LSMTree()
+    lsm = LSMTree(ROOT_DIR / "lsm_segments")
     assert lsm.get_floor_ceil_of_key_in_index(input_key, test_tree) == expected_output
 
 
@@ -61,7 +61,11 @@ LIST_OF_NUMS = [
 
 def test_read_from_db() -> None:
     with TemporaryDirectory(dir=ROOT_DIR) as tmp:
-        lsmtree = LSMTree(10, 3)
+        lsmtree = LSMTree(
+            segment_folder_path=ROOT_DIR / "lsm_segments",
+            memtable_max_size=10,
+            segment_chunk_size_for_indexing=3,
+        )
         lsmtree.segment_folder_path = Path(tmp)
         for num in LIST_OF_NUMS:
             lsmtree.write(num, num2words(num))
@@ -177,7 +181,11 @@ LONGER_LIST_OF_NUMS = [
 def test_write_to_db() -> None:
     # Expect 3 files and a memtable with 25 els. as Dupes are in different segments
     with TemporaryDirectory(dir=ROOT_DIR) as tmp:
-        lsmtree = LSMTree(25, 5)
+        lsmtree = LSMTree(
+            segment_folder_path=ROOT_DIR / "lsm_segments",
+            memtable_max_size=25,
+            segment_chunk_size_for_indexing=5,
+        )
         lsmtree.segment_folder_path = Path(tmp)
         for num in LONGER_LIST_OF_NUMS:
             lsmtree.write(num, num2words(num))
@@ -254,3 +262,7 @@ def test_compact_segment_files(
             actual = list(f.readlines())
 
         assert actual == expected_merged_file_contents
+
+
+def test_save_index_to_file() -> None:
+    pass

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -8,7 +8,7 @@ from sortedcontainers import SortedDict
 
 from sandb.config import ROOT_DIR
 from sandb.indexes.abc import Comparable
-from sandb.indexes.lsm_tree import LSMTree, merge_segment_files
+from sandb.indexes.lsm_tree import LSMTree, merge_segment_files, save_index_to_file
 
 
 @pytest.mark.parametrize(  # type: ignore
@@ -265,4 +265,9 @@ def test_compact_segment_files(
 
 
 def test_save_index_to_file() -> None:
-    pass
+    index_to_save = SortedDict({"a": 10, "b": 20, "c": 30})
+
+    with TemporaryDirectory() as tmp:
+        save_index_to_file(Path(tmp), index_to_save)
+        with open(Path(tmp) / "index.txt", "r") as f:
+            assert f.read() == """a:10\nb:20\nc:30\n\n"""

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -9,6 +9,7 @@ from sortedcontainers import SortedDict
 from sandb.config import ROOT_DIR
 from sandb.indexes.abc import Comparable
 from sandb.indexes.lsm_tree import LSMTree, merge_segment_files, save_index_to_file
+from sandb.tables.metadata import Column, LSMTreeMetadata
 
 
 @pytest.mark.parametrize(  # type: ignore
@@ -31,8 +32,18 @@ def test_get_floor_ceil_of_key_in_index(
     expected_output: tuple[int, int | None],
     test_tree: SortedDict[Comparable, int],
 ) -> None:
-    lsm = LSMTree(ROOT_DIR / "lsm_segments")
-    assert lsm.get_floor_ceil_of_key_in_index(input_key, test_tree) == expected_output
+    with TemporaryDirectory(dir=ROOT_DIR) as tmp:
+        lsm = LSMTree(
+            lsmtree_metadata=LSMTreeMetadata(
+                folder_path=Path(tmp),
+                memtable_max_size=1000,
+                segment_chunk_size_for_indexing=100,
+                primary_key=Column(name="col_1", dtype=int),
+            ),
+        )
+        assert (
+            lsm.get_floor_ceil_of_key_in_index(input_key, test_tree) == expected_output
+        )
 
 
 LIST_OF_NUMS = [
@@ -62,9 +73,12 @@ LIST_OF_NUMS = [
 def test_read_from_db() -> None:
     with TemporaryDirectory(dir=ROOT_DIR) as tmp:
         lsmtree = LSMTree(
-            segment_folder_path=ROOT_DIR / "lsm_segments",
-            memtable_max_size=10,
-            segment_chunk_size_for_indexing=3,
+            lsmtree_metadata=LSMTreeMetadata(
+                folder_path=Path(tmp),
+                memtable_max_size=10,
+                segment_chunk_size_for_indexing=3,
+                primary_key=Column(name="col_1", dtype=int),
+            ),
         )
         lsmtree.segment_folder_path = Path(tmp)
         for num in LIST_OF_NUMS:
@@ -182,15 +196,23 @@ def test_write_to_db() -> None:
     # Expect 3 files and a memtable with 25 els. as Dupes are in different segments
     with TemporaryDirectory(dir=ROOT_DIR) as tmp:
         lsmtree = LSMTree(
-            segment_folder_path=ROOT_DIR / "lsm_segments",
-            memtable_max_size=25,
-            segment_chunk_size_for_indexing=5,
+            lsmtree_metadata=LSMTreeMetadata(
+                folder_path=Path(tmp),
+                memtable_max_size=25,
+                segment_chunk_size_for_indexing=5,
+                primary_key=Column(name="col_1", dtype=int),
+            ),
         )
-        lsmtree.segment_folder_path = Path(tmp)
         for num in LONGER_LIST_OF_NUMS:
             lsmtree.write(num, num2words(num))
 
-        assert os.listdir(tmp) == ["segment_0.txt", "segment_1.txt", "segment_2.txt"]
+        print(os.listdir(tmp))
+
+        assert os.listdir(Path(tmp) / "segments") == [
+            "segment_0.txt",
+            "segment_1.txt",
+            "segment_2.txt",
+        ]
         assert len(lsmtree.memtable) == 25
 
 
@@ -271,3 +293,7 @@ def test_save_index_to_file() -> None:
         save_index_to_file(Path(tmp), index_to_save)
         with open(Path(tmp) / "index.txt", "r") as f:
             assert f.read() == """a:10\nb:20\nc:30\n\n"""
+
+
+def test_load_indexes_from_file() -> None:
+    pass

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -250,7 +250,7 @@ def test_write_to_db() -> None:
             ],
         ),
         (
-            [[1, 2, 3], []],  # type: ignore
+            [[1, 2, 3], []],  # type: ignore[unused-ignore]
             [
                 "1: one_1\n",
                 "2: two_1\n",

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -319,8 +319,6 @@ def test_load_indexes_from_file(mock_glob: MagicMock) -> None:
             )
         )
 
-        print(tree.indexes)
-
         assert tree.indexes == OrderedDict(
             [
                 (Path(tmp) / "segments/segment_0.txt", index_1),

--- a/tests/sandb/indexes/test_lsm_tree.py
+++ b/tests/sandb/indexes/test_lsm_tree.py
@@ -1,13 +1,14 @@
 import os
+from collections import OrderedDict
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
 
 import pytest
 from num2words import num2words
 from sortedcontainers import SortedDict
 
-from sandb.config import ROOT_DIR
-from sandb.indexes.abc import Comparable
+from sandb.config import ROOT_DIR, VALID_DTYPE
 from sandb.indexes.lsm_tree import LSMTree, merge_segment_files, save_index_to_file
 from sandb.tables.metadata import Column, LSMTreeMetadata
 
@@ -30,7 +31,7 @@ from sandb.tables.metadata import Column, LSMTreeMetadata
 def test_get_floor_ceil_of_key_in_index(
     input_key: str,
     expected_output: tuple[int, int | None],
-    test_tree: SortedDict[Comparable, int],
+    test_tree: dict[VALID_DTYPE, int],
 ) -> None:
     with TemporaryDirectory(dir=ROOT_DIR) as tmp:
         lsm = LSMTree(
@@ -42,7 +43,7 @@ def test_get_floor_ceil_of_key_in_index(
             ),
         )
         assert (
-            lsm.get_floor_ceil_of_key_in_index(input_key, test_tree) == expected_output
+            lsm._get_floor_ceil_of_key_in_index(input_key, test_tree) == expected_output
         )
 
 
@@ -295,5 +296,34 @@ def test_save_index_to_file() -> None:
             assert f.read() == """a:10\nb:20\nc:30\n\n"""
 
 
-def test_load_indexes_from_file() -> None:
-    pass
+@patch("sandb.indexes.lsm_tree.glob")
+def test_load_indexes_from_file(mock_glob: MagicMock) -> None:
+    mock_glob.return_value = [1, 2]
+    index_1 = SortedDict({"a": 10, "b": 20, "c": 30})
+    index_2 = SortedDict({"d": 10, "e": 20, "f": 30})
+
+    with TemporaryDirectory() as tmp:
+        save_index_to_file(Path(tmp), index_1)
+        save_index_to_file(Path(tmp), index_2)
+
+        # get lsmtree to load from file rather
+        # than creating everything from scratch
+        (Path(tmp) / "metadata.json").touch()
+
+        tree = LSMTree(
+            LSMTreeMetadata(
+                folder_path=Path(tmp),
+                memtable_max_size=100,
+                segment_chunk_size_for_indexing=10,
+                primary_key=Column(name="col_1", dtype=str),
+            )
+        )
+
+        print(tree.indexes)
+
+        assert tree.indexes == OrderedDict(
+            [
+                (Path(tmp) / "segments/segment_0.txt", index_1),
+                (Path(tmp) / "segments/segment_1.txt", index_2),
+            ]
+        )


### PR DESCRIPTION
Allows the sparse indexes used within the LSM tree for efficient lookup to be dumped and loaded from file for use between sessions.