### PR TITLE
 add add_records to slotted page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: 6.1.0
     hooks:
     -   id: flake8
-        args: [--max-line-length=88, --ignore=E203]
+        args: [--max-line-length=88, --ignore=E203, --extend-ignore=W503]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1
     hooks:

--- a/src/sandb/storage/database.py
+++ b/src/sandb/storage/database.py
@@ -64,7 +64,7 @@ class Database:
             page_directory_size,
         )
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         """
         Serializes the Database instance into a byte string.
 

--- a/src/sandb/storage/page_directory.py
+++ b/src/sandb/storage/page_directory.py
@@ -48,7 +48,7 @@ class PageDirectoryHeader:
     directory_size: int
     page_pointers: list[PagePointer]
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         """
         Serializes the PageDirectoryHeader into a byte string.
 

--- a/src/sandb/storage/record.py
+++ b/src/sandb/storage/record.py
@@ -34,7 +34,7 @@ class SchemaRecord:
     ]  # TODO: need to add dtype lengths in here as well i.e. VARCHAR(50)
     col_names: list[str]
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         """
         Serializes the SchemaRecord instance into a bytes representation.
 

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -76,8 +76,12 @@ class SlottedPageHeader:
     is_dirty: bool = False
     next_row_id: int = 0
     # checksum: int | None  # TODO implement this later
-    # TODO: Should I include all my records here once loaded into memory?
-    #       Or retrieve from disk using the pointers?
+
+    def __post_init__(self) -> None:
+        if self.slots:
+            self.next_row_id = max([slot.record_id for slot in self.slots]) + 1
+        else:
+            self.next_row_id = 0
 
     def __bytes__(self) -> bytes:
         """

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -4,7 +4,6 @@ from struct import pack, unpack_from
 from typing import Iterable, Iterator
 
 from sandb.storage.constants import INT_SIZE_IN_BYTES
-from sandb.storage.record import SchemaRecord
 
 SLOT_SIZE = 3 * INT_SIZE_IN_BYTES
 SLOTTED_PAGE_HEADER_METADATA_SIZE = 4 * INT_SIZE_IN_BYTES
@@ -14,6 +13,14 @@ class PageFullException(Exception):
     """
     Exception to raise if we don't have enough space
     to add a record to the slotted page.
+    """
+
+    ...
+
+
+class RecordNotInPage(Exception):
+    """
+    Exception to raise when a record id is not found in a given page
     """
 
     ...
@@ -157,8 +164,11 @@ class SlottedPage:
 
     header: SlottedPageHeader
     byte_str: bytearray
-    schema_record: SchemaRecord
     size: int = 4096
+
+    def _update_byte_str_with_header(self) -> None:
+        serialised_header = bytes(self.header)
+        self.byte_str[: len(serialised_header)] = serialised_header
 
     @classmethod
     def from_bytes(cls, byte_str: bytes) -> "SlottedPage":
@@ -176,13 +186,10 @@ class SlottedPage:
             SlottedPage: A SlottedPage object deserialized from the byte string.
         """
         slotted_page_header = SlottedPageHeader.from_bytes(byte_str)
-        schema_offset = slotted_page_header.slots[0].record_pointer
 
-        schema_record = SchemaRecord.from_bytes(byte_str[schema_offset:])
+        return SlottedPage(slotted_page_header, bytearray(byte_str))
 
-        return SlottedPage(slotted_page_header, bytearray(byte_str), schema_record)
-
-    def add_record(self, record: bytes) -> None:
+    def add_record(self, record: bytes) -> int:
         """
         Adds a new record to the slotted page.
 
@@ -207,8 +214,10 @@ class SlottedPage:
                     {required_space} in length."""
             )
 
+        record_id = self.header.next_row_id
+
         slot = Slot(
-            record_id=self.header.next_row_id,
+            record_id=record_id,
             record_pointer=self.header.free_space_end - record_length,
             record_length=record_length,
         )
@@ -222,10 +231,106 @@ class SlottedPage:
         record_end_offset = self.header.free_space_end
         self.byte_str[record_start_offset:record_end_offset] = record
 
-        # Update header metadata: move free space pointers, serialize and write header
-        self.header.free_space_start += SLOT_SIZE  # Slot directory grows forward
-        self.header.free_space_end -= record_length  # Record area grows backward
-        serialised_header = bytes(self.header)
-        self.byte_str[: len(serialised_header)] = serialised_header
+        self.header.free_space_start += SLOT_SIZE
+        self.header.free_space_end -= record_length
+
+        self._update_byte_str_with_header()
 
         self.is_dirty = True
+        return record_id
+
+    def delete(self, record_id: int) -> None:
+        """
+        Deletes a record from the slotted page by record ID.
+
+        This method logically deletes a record by invalidating its slot
+        (setting record_pointer to 0). The record data remains in the
+        byte array, but the space is not immediately reclaimed.
+
+        Args:
+            record_id (int): The ID of the record to delete.
+
+        Raises:
+            RecordNotInPage: If the record_id is not found in the page.
+
+        Side Effects:
+            - Modifies the slot directory in the SlottedPageHeader.
+            - Updates the SlottedPageHeader in the byte_str.
+            - Sets the is_dirty flag on the SlottedPageHeader.
+        """
+
+        have_modified = False
+        for slot in self.header.slots:
+            if slot.record_id == record_id:
+                slot.record_pointer = 0
+                have_modified = True
+                break
+
+        if have_modified:
+            self._update_byte_str_with_header()
+            self.header.is_dirty = True
+
+        else:
+            raise RecordNotInPage(
+                f"Could not find record: {record_id} in page: {self.header.page_id}"
+            )
+
+    def update(self, record_id: int, record: bytes) -> int:
+        """
+        Updates an existing record in the slotted page.
+
+        If the new record is smaller than or equal to the old record's size,
+        it performs an in-place update. If the new record is larger, it
+        attempts to relocate the record: adds the new record to available
+        space and marks the old record's slot as deleted.
+
+        Args:
+            record_id (int): The ID of the record to update.
+            record (bytes): The new byte data for the record.
+
+        Returns:
+            int: The record_id of the updated record. This will be the original
+                 record_id for in-place updates, or a new record_id if relocation
+                 was necessary.
+
+        Raises:
+            RecordNotInPage: If the record_id is not found in the page.
+            PageFullException: If relocation is needed but there is not enough
+                               space on the page to add the new, larger record.
+
+        Side Effects:
+            - Modifies the record data in byte_str (in-place or by relocation).
+            - Updates the slot directory in SlottedPageHeader (slot length or marks
+              slot as deleted during relocation).
+            - Updates free space pointers in SlottedPageHeader (during relocation).
+            - Updates the SlottedPageHeader in the byte_str.
+            - Sets the is_dirty flag on the SlottedPageHeader.
+        """
+        have_modified = False
+        new_record_length = len(record)
+        for slot in self.header.slots:
+            if slot.record_id == record_id:
+                have_modified = True
+                if new_record_length <= slot.record_length:
+                    self.byte_str[
+                        slot.record_pointer : slot.record_pointer + new_record_length
+                    ] = record
+                    slot.record_length = new_record_length
+                    self._update_byte_str_with_header()
+
+                else:
+                    try:
+                        new_record_id = self.add_record(record)
+                        self.delete(record_id)
+                        record_id = new_record_id
+                    except PageFullException:
+                        raise PageFullException(
+                            f"""Can't update record: {record_id} as
+                                not enough space in page"""
+                        )
+        if not have_modified:
+            raise RecordNotInPage(
+                f"Could not find record: {record_id} in page: {self.header.page_id}"
+            )
+        self.header.is_dirty = True
+        return record_id

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -6,6 +6,8 @@ from typing import Iterable, Iterator
 from sandb.storage.constants import INT_SIZE_IN_BYTES
 from sandb.storage.record import SchemaRecord
 
+SLOT_SIZE = 3 * INT_SIZE_IN_BYTES
+
 
 @dataclass
 class Slot(Iterable[int]):
@@ -91,7 +93,7 @@ class SlottedPageHeader:
             len_slots,
         ) = unpack_from("<iiii", byte_str, offset)
 
-        offset += INT_SIZE_IN_BYTES * 4 - 1
+        offset += INT_SIZE_IN_BYTES * 4
 
         slots_raw = unpack_from("<" + f"{len_slots * 3}i", byte_str, offset)
         offset += 3 * INT_SIZE_IN_BYTES * len_slots
@@ -129,12 +131,11 @@ class SlottedPage:
         return SlottedPage(slotted_page_header, bytearray(byte_str), schema_record)
 
     def add_record(self, record: bytes) -> None:
-        # TODO: How do I make all this atomic?
         record_length = len(record)
 
         slot = Slot(
             record_id=self.header.next_row_id,
-            record_pointer=self.header.free_space_end + 1 - record_length,
+            record_pointer=self.header.free_space_end - record_length,
             record_length=record_length,
         )
         self.header.next_row_id += 1
@@ -142,20 +143,14 @@ class SlottedPage:
         self.header.slots.append(slot)
 
         self.byte_str[
-            self.header.free_space_start : self.header.free_space_start
-            + 3 * INT_SIZE_IN_BYTES  # noqa
-        ] = slot.to_bytes()
-
-        self.byte_str[
             self.header.free_space_end - record_length : self.header.free_space_end
         ] = record
 
-        self.byte_str[4:17] = bytearray(
-            pack(
-                "<iii",
-                self.header.free_space_start + 3 * INT_SIZE_IN_BYTES,
-                self.header.free_space_end - record_length,
-                len(self.header.slots),
-            )
-        )
+        self.header.free_space_start = self.header.free_space_start + SLOT_SIZE
+        self.header.free_space_end = self.header.free_space_end - record_length
+
+        serialised_header = self.header.to_bytes()
+
+        self.byte_str[: len(serialised_header)] = serialised_header
+
         self.is_dirty = True

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -73,7 +73,6 @@ class SlottedPageHeader:
     free_space_start: int
     free_space_end: int
     slots: list[Slot]
-    is_dirty: bool = False
     next_row_id: int = 0
     # checksum: int | None  # TODO implement this later
 
@@ -169,6 +168,7 @@ class SlottedPage:
     header: SlottedPageHeader
     byte_str: bytearray
     size: int = 4096
+    is_dirty: bool = False
 
     def _update_byte_str_with_header(self) -> None:
         serialised_header = bytes(self.header)
@@ -272,7 +272,7 @@ class SlottedPage:
 
         if have_modified:
             self._update_byte_str_with_header()
-            self.header.is_dirty = True
+            self.is_dirty = True
 
         else:
             raise RecordNotInPage(
@@ -336,5 +336,5 @@ class SlottedPage:
             raise RecordNotInPage(
                 f"Could not find record: {record_id} in page: {self.header.page_id}"
             )
-        self.header.is_dirty = True
+        self.is_dirty = True
         return record_id

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -10,19 +10,37 @@ SLOT_SIZE = 3 * INT_SIZE_IN_BYTES
 SLOTTED_PAGE_HEADER_METADATA_SIZE = 4 * INT_SIZE_IN_BYTES
 
 
+class PageFullException(Exception):
+    """
+    Exception to raise if we don't have enough space
+    to add a record to the slotted page.
+    """
+
+    ...
+
+
 @dataclass
 class Slot(Iterable[int]):
     """
     Represents a slot within a slotted page.
-    Each slot contains a record ID, a pointer to the record's location,
-    and the record's length.
+
+    Each slot contains metadata about a record: record ID,
+    record pointer (offset), and record length.
+    Slots are stored in the SlottedPageHeader's slot directory.
     """
 
     record_id: int
     record_pointer: int
     record_length: int
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
+        """
+        Serializes the Slot object into a byte string.
+
+        Returns:
+            bytes: Byte representation of the slot
+                   (record_id, record_pointer, record_length).
+        """
         return pack("<iii", self.record_id, self.record_pointer, self.record_length)
 
     def __iter__(self) -> Iterator[int]:
@@ -38,7 +56,10 @@ class Slot(Iterable[int]):
 @dataclass
 class SlottedPageHeader:
     """
-    Represents the header of a slotted page, including metadata and slot directory.
+    Represents the header of a slotted page.
+
+    The header contains metadata about the page and the slot directory,
+    which points to records stored within the page's byte array.
     """
 
     page_id: int
@@ -51,9 +72,16 @@ class SlottedPageHeader:
     # TODO: Should I include all my records here once loaded into memory?
     #       Or retrieve from disk using the pointers?
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         """
         Serializes the SlottedPageHeader to a byte string.
+
+        The serialized format includes:
+        - page_id (int)
+        - free_space_start (int)
+        - free_space_end (int)
+        - number of slots (int)
+        - slot directory (array of Slot objects, each serialized to bytes)
 
         Returns:
             bytes: Serialized representation of the header and its slots.
@@ -97,7 +125,7 @@ class SlottedPageHeader:
         offset += SLOTTED_PAGE_HEADER_METADATA_SIZE
 
         slots_raw = unpack_from("<" + f"{len_slots * 3}i", byte_str, offset)
-        offset += 3 * INT_SIZE_IN_BYTES * len_slots
+        offset += SLOT_SIZE * len_slots
         slots = [
             Slot(
                 record_id=slots_raw[slot_ind],
@@ -117,13 +145,36 @@ class SlottedPageHeader:
 
 @dataclass
 class SlottedPage:
+    """
+    Represents a slotted page, which is a unit of storage on
+    disk.
+
+    A slotted page contains a header (SlottedPageHeader),
+    a byte array to store page content, and schema information
+    (SchemaRecord). It manages records using a slot directory
+    within the header.
+    """
+
     header: SlottedPageHeader
     byte_str: bytearray
     schema_record: SchemaRecord
-    size: int = 150
+    size: int = 4096
 
     @classmethod
     def from_bytes(cls, byte_str: bytes) -> "SlottedPage":
+        """
+        Creates a SlottedPage object by deserializing from a byte string.
+
+        This method reconstructs the SlottedPageHeader and SchemaRecord
+        from the byte string.
+
+        Args:
+            byte_str (bytes): Byte representation of the entire slotted
+            page (header + data).
+
+        Returns:
+            SlottedPage: A SlottedPage object deserialized from the byte string.
+        """
         slotted_page_header = SlottedPageHeader.from_bytes(byte_str)
         schema_offset = slotted_page_header.slots[0].record_pointer
 
@@ -132,7 +183,29 @@ class SlottedPage:
         return SlottedPage(slotted_page_header, bytearray(byte_str), schema_record)
 
     def add_record(self, record: bytes) -> None:
+        """
+        Adds a new record to the slotted page.
+
+        This method adds the record data to the page's byte array and creates a new slot
+        in the SlottedPageHeader's slot directory to point to the record.
+
+        Args:
+            record (bytes): The byte data of the record to be added.
+
+        Raises:
+            PageFullException: If there is not enough free space on the page to add the
+            record.
+        """
         record_length = len(record)
+        required_space = record_length + SLOT_SIZE
+        available_space = self.header.free_space_end - self.header.free_space_start
+
+        if required_space > available_space:
+            raise PageFullException(
+                f"""Can't add record to page {self.header.page_id} as not enough space.
+                    We have {available_space} bytes free and the record is
+                    {required_space} in length."""
+            )
 
         slot = Slot(
             record_id=self.header.next_row_id,
@@ -143,15 +216,16 @@ class SlottedPage:
 
         self.header.slots.append(slot)
 
-        self.byte_str[
-            self.header.free_space_end - record_length : self.header.free_space_end
-        ] = record
+        # Write record data to the free space area
+        # at the end of the page growing backwards
+        record_start_offset = self.header.free_space_end - record_length
+        record_end_offset = self.header.free_space_end
+        self.byte_str[record_start_offset:record_end_offset] = record
 
-        self.header.free_space_start = self.header.free_space_start + SLOT_SIZE
-        self.header.free_space_end = self.header.free_space_end - record_length
-
-        serialised_header = self.header.to_bytes()
-
+        # Update header metadata: move free space pointers, serialize and write header
+        self.header.free_space_start += SLOT_SIZE  # Slot directory grows forward
+        self.header.free_space_end -= record_length  # Record area grows backward
+        serialised_header = bytes(self.header)
         self.byte_str[: len(serialised_header)] = serialised_header
 
         self.is_dirty = True

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -4,6 +4,7 @@ from struct import pack, unpack_from
 from typing import Iterable, Iterator
 
 from sandb.storage.constants import INT_SIZE_IN_BYTES
+from sandb.storage.record import SchemaRecord
 
 
 @dataclass
@@ -17,6 +18,9 @@ class Slot(Iterable[int]):
     record_id: int
     record_pointer: int
     record_length: int
+
+    def to_bytes(self) -> bytes:
+        return pack("<iii", self.record_id, self.record_pointer, self.record_length)
 
     def __iter__(self) -> Iterator[int]:
         """
@@ -38,7 +42,8 @@ class SlottedPageHeader:
     free_space_start: int
     free_space_end: int
     slots: list[Slot]
-    records: list[bytes]
+    is_dirty: bool = False
+    next_row_id: int = 0
     # checksum: int | None  # TODO implement this later
     # TODO: Should I include all my records here once loaded into memory?
     #       Or retrieve from disk using the pointers?
@@ -65,9 +70,6 @@ class SlottedPageHeader:
 
         byte_str = byte_str.ljust(self.free_space_end, b"\0")
 
-        for record in self.records:
-            byte_str += record
-
         return byte_str
 
     @classmethod
@@ -89,7 +91,7 @@ class SlottedPageHeader:
             len_slots,
         ) = unpack_from("<iiii", byte_str, offset)
 
-        offset += INT_SIZE_IN_BYTES * 4
+        offset += INT_SIZE_IN_BYTES * 4 - 1
 
         slots_raw = unpack_from("<" + f"{len_slots * 3}i", byte_str, offset)
         offset += 3 * INT_SIZE_IN_BYTES * len_slots
@@ -101,13 +103,59 @@ class SlottedPageHeader:
             )
             for slot_ind in range(0, 3 * len_slots, 3)
         ]
-        records: list[bytes] = []
-        offset = free_space_end
-
-        for slot in slots:
-            records.append(byte_str[offset : offset + slot.record_length])
-            offset += slot.record_length
 
         return SlottedPageHeader(
-            page_id, free_space_start, free_space_end, slots, records
+            page_id,
+            free_space_start,
+            free_space_end,
+            slots,
         )
+
+
+@dataclass
+class SlottedPage:
+    header: SlottedPageHeader
+    byte_str: bytearray
+    schema_record: SchemaRecord
+    size: int = 150
+
+    @classmethod
+    def from_bytes(cls, byte_str: bytes) -> "SlottedPage":
+        slotted_page_header = SlottedPageHeader.from_bytes(byte_str)
+        schema_offset = slotted_page_header.slots[0].record_pointer
+
+        schema_record = SchemaRecord.from_bytes(byte_str[schema_offset:])
+
+        return SlottedPage(slotted_page_header, bytearray(byte_str), schema_record)
+
+    def add_record(self, record: bytes) -> None:
+        # TODO: How do I make all this atomic?
+        record_length = len(record)
+
+        slot = Slot(
+            record_id=self.header.next_row_id,
+            record_pointer=self.header.free_space_end + 1 - record_length,
+            record_length=record_length,
+        )
+        self.header.next_row_id += 1
+
+        self.header.slots.append(slot)
+
+        self.byte_str[
+            self.header.free_space_start : self.header.free_space_start
+            + 3 * INT_SIZE_IN_BYTES  # noqa
+        ] = slot.to_bytes()
+
+        self.byte_str[
+            self.header.free_space_end - record_length : self.header.free_space_end
+        ] = record
+
+        self.byte_str[4:17] = bytearray(
+            pack(
+                "<iii",
+                self.header.free_space_start + 3 * INT_SIZE_IN_BYTES,
+                self.header.free_space_end - record_length,
+                len(self.header.slots),
+            )
+        )
+        self.is_dirty = True

--- a/src/sandb/storage/slotted_page.py
+++ b/src/sandb/storage/slotted_page.py
@@ -7,6 +7,7 @@ from sandb.storage.constants import INT_SIZE_IN_BYTES
 from sandb.storage.record import SchemaRecord
 
 SLOT_SIZE = 3 * INT_SIZE_IN_BYTES
+SLOTTED_PAGE_HEADER_METADATA_SIZE = 4 * INT_SIZE_IN_BYTES
 
 
 @dataclass
@@ -93,7 +94,7 @@ class SlottedPageHeader:
             len_slots,
         ) = unpack_from("<iiii", byte_str, offset)
 
-        offset += INT_SIZE_IN_BYTES * 4
+        offset += SLOTTED_PAGE_HEADER_METADATA_SIZE
 
         slots_raw = unpack_from("<" + f"{len_slots * 3}i", byte_str, offset)
         offset += 3 * INT_SIZE_IN_BYTES * len_slots

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,3 +74,20 @@ def slotted_page(schema_record: SchemaRecord):
     slotted_page.add_record(record3)
 
     return slotted_page
+
+
+@pytest.fixture  # type: ignore
+def slotted_page_empty() -> SlottedPage:
+    """Fixture for an empty SlottedPage."""
+    page_size = 4096
+    header = SlottedPageHeader(
+        page_id=0,
+        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE,
+        free_space_end=page_size,
+        slots=[],
+    )
+    return SlottedPage(
+        header=header,
+        byte_str=bytearray(bytes(header).ljust((page_size), b"\0")),
+        size=page_size,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,12 @@ import pytest
 from pytest import TempPathFactory
 from sortedcontainers import SortedDict
 
+from sandb.storage.record import SchemaRecord
+from sandb.storage.slotted_page import (
+    SLOTTED_PAGE_HEADER_METADATA_SIZE,
+    SlottedPage,
+    SlottedPageHeader,
+)
 from sandb.tables.metadata import Column, TableMetadata
 
 
@@ -33,3 +39,38 @@ def test_table_metadata(tmp_path_factory: TempPathFactory) -> TableMetadata:
         columns=(Column(name="col_1", dtype=str), Column(name="col_2", dtype=int)),
         location=path,
     )
+
+
+@pytest.fixture  # type: ignore
+def schema_record() -> SchemaRecord:
+    return SchemaRecord(
+        table_id=0,
+        table_name="table_1",
+        dtypes=[1, 0],
+        col_names=["str_col", "int_col"],
+    )
+
+
+@pytest.fixture(scope="function")  # type: ignore
+def slotted_page(schema_record: SchemaRecord):
+    """Fixture to set up a SlottedPage with initial records for testing."""
+    header = SlottedPageHeader(
+        page_id=0,
+        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE,
+        free_space_end=4096,
+        slots=[],
+    )
+
+    slotted_page = SlottedPage(header=header, byte_str=bytearray(4096))
+
+    slotted_page.add_record(bytes(schema_record))
+
+    record1 = b"record_data_1"
+    record2 = b"record_data_2_longer"
+    record3 = b"record_data_3"
+
+    slotted_page.add_record(record1)
+    slotted_page.add_record(record2)
+    slotted_page.add_record(record3)
+
+    return slotted_page

--- a/tests/integration/sandb/storage/test_storage.py
+++ b/tests/integration/sandb/storage/test_storage.py
@@ -5,16 +5,21 @@ from tempfile import TemporaryDirectory
 from sandb.storage.database import Database
 from sandb.storage.page_directory import PageDirectoryHeader, PagePointer
 from sandb.storage.record import SchemaRecord
-from sandb.storage.slotted_page import Slot, SlottedPageHeader
+from sandb.storage.slotted_page import (
+    SLOTTED_PAGE_HEADER_METADATA_SIZE,
+    SlottedPage,
+    SlottedPageHeader,
+)
 
 
 def test_database_with_page_directory_and_slotted_pages() -> None:
+    page_size = 4096
     with TemporaryDirectory() as tmp:
         database = Database(
             file_path=Path(tmp) / "database",
             version="v0.0.1",
-            page_size_bytes=200,
-            page_directory_size_bytes=200,
+            page_size_bytes=page_size,
+            page_directory_size_bytes=page_size,
         )
 
         page_directory = PageDirectoryHeader(
@@ -37,35 +42,31 @@ def test_database_with_page_directory_and_slotted_pages() -> None:
             col_names=["str_col", "int_col"],
         )
 
-        schema_record_length = len(schema_record.to_bytes())
+        schema_record_length = len(bytes(schema_record))
 
         schema_slot_offset = database.page_size_bytes - schema_record_length
 
         record = pack("<3si", "abc".encode("utf-8"), 10)
 
-        slotted_page = SlottedPageHeader(
+        slotted_page_header = SlottedPageHeader(
             page_id=0,
-            free_space_start=28,
+            free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE,
             free_space_end=schema_slot_offset - len(record),
-            slots=[
-                Slot(
-                    record_id=0,
-                    record_pointer=schema_slot_offset,
-                    record_length=schema_record_length,
-                ),
-                Slot(
-                    record_id=1,
-                    record_pointer=schema_slot_offset - len(record),
-                    record_length=len(record),
-                ),
-            ],
-            records=[schema_record.to_bytes(), record],
+            slots=[],
         )
 
+        slotted_page = SlottedPage(
+            slotted_page_header,
+            bytearray(bytes(slotted_page_header).ljust((page_size), b"\0")),
+            page_size,
+        )
+        slotted_page.add_record(bytes(schema_record))
+        slotted_page.add_record(record)
+
         with open(database.file_path, "wb") as f:
-            f.write(database.to_bytes())
-            f.write(page_directory.to_bytes())
-            f.write(slotted_page.to_bytes())
+            f.write(bytes(database))
+            f.write(bytes(page_directory))
+            f.write(slotted_page.byte_str)
 
         with open(database.file_path, "rb") as f:
             loaded_database = Database.from_bytes(f.read(100), database.file_path)
@@ -73,11 +74,10 @@ def test_database_with_page_directory_and_slotted_pages() -> None:
             loaded_page_directory = database.page_directory
 
             f.seek(page_directory.page_pointers[0].page_start)
-            loaded_slotted_page = SlottedPageHeader.from_bytes(
+            loaded_slotted_page = SlottedPage.from_bytes(
                 f.read(database.page_size_bytes)
             )
 
         assert database == loaded_database
         assert page_directory == loaded_page_directory
         assert slotted_page == loaded_slotted_page
-        assert schema_record == SchemaRecord.from_bytes(loaded_slotted_page.records[0])

--- a/tests/integration/sandb/storage/test_storage.py
+++ b/tests/integration/sandb/storage/test_storage.py
@@ -77,6 +77,7 @@ def test_database_with_page_directory_and_slotted_pages() -> None:
             loaded_slotted_page = SlottedPage.from_bytes(
                 f.read(database.page_size_bytes)
             )
+            loaded_slotted_page.is_dirty = True  # This is a bit naughty, but necessary
 
         assert database == loaded_database
         assert page_directory == loaded_page_directory

--- a/tests/unit/sandb/storage/test_database.py
+++ b/tests/unit/sandb/storage/test_database.py
@@ -13,7 +13,7 @@ def test_to_bytes() -> None:
         page_directory_size_bytes=100,
     )
 
-    encoded_database = database.to_bytes()
+    encoded_database = bytes(database)
 
     assert Database.from_bytes(encoded_database, Path("abc")) == database
 
@@ -33,7 +33,7 @@ def test_database_page_directory_cohesion() -> None:
         page = PageDirectoryHeader(1, 2, 3, [PagePointer(1, 2), PagePointer(3, 4)])
 
         with open(file_path, "wb") as f:
-            f.write(database.to_bytes())
-            f.write(page.to_bytes())
+            f.write(bytes(database))
+            f.write(bytes(page))
 
         assert database.page_directory == page

--- a/tests/unit/sandb/storage/test_page_directory.py
+++ b/tests/unit/sandb/storage/test_page_directory.py
@@ -10,4 +10,4 @@ def test_to_bytes() -> None:
         file_path.touch()
         page = PageDirectoryHeader(1, 2, 3, [PagePointer(1, 2), PagePointer(3, 4)])
 
-        assert PageDirectoryHeader.from_bytes(page.to_bytes()) == page
+        assert PageDirectoryHeader.from_bytes(bytes(page)) == page

--- a/tests/unit/sandb/storage/test_record.py
+++ b/tests/unit/sandb/storage/test_record.py
@@ -4,4 +4,4 @@ from sandb.storage.record import SchemaRecord
 def test_schema_record_binary_storage() -> None:
     schema_record = SchemaRecord(0, "table_1", [0, 1], col_names=["col_1", "col_2"])
 
-    assert schema_record == schema_record.from_bytes(schema_record.to_bytes())
+    assert schema_record == schema_record.from_bytes(bytes(schema_record))

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -21,8 +21,8 @@ def test_slotted_page_add_record() -> None:
     header = SlottedPageHeader(
         page_id=0,
         free_space_start=28,
-        free_space_end=99,
-        slots=[Slot(record_id=0, record_pointer=100, record_length=4)],
+        free_space_end=101,
+        slots=[Slot(record_id=0, record_pointer=101, record_length=4)],
         next_row_id=1,
     )
 
@@ -45,6 +45,6 @@ def test_slotted_page_add_record() -> None:
     updated_slotted_page = SlottedPage.from_bytes(bytes(slotted_page.byte_str))
 
     assert updated_slotted_page.header.free_space_start == 40
-    assert updated_slotted_page.header.free_space_end == 92
-    assert updated_slotted_page.header.slots[1] == Slot(1, 93, 7)
+    assert updated_slotted_page.header.free_space_end == 94
+    assert updated_slotted_page.header.slots[1] == Slot(1, 94, 7)
     assert updated_slotted_page.schema_record == schema_record

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -19,7 +19,7 @@ def test_slotted_page_header_serialisation() -> None:
     )
 
     assert slotted_page_header == SlottedPageHeader.from_bytes(
-        slotted_page_header.to_bytes()
+        bytes(slotted_page_header)
     )
 
 
@@ -28,7 +28,7 @@ def test_slotted_page_add_record() -> None:
     schema_record = SchemaRecord(
         0, "table_1", dtypes=[1, 0], col_names=["str_col", "int_col"]
     )
-    schema_record_bytes = schema_record.to_bytes()
+    schema_record_bytes = bytes(schema_record)
     free_space_end = page_size - len(schema_record_bytes)
 
     header = SlottedPageHeader(
@@ -48,8 +48,7 @@ def test_slotted_page_add_record() -> None:
     slotted_page = SlottedPage(
         header=header,
         byte_str=bytearray(
-            header.to_bytes().ljust((free_space_end), b"\0")
-            + schema_record_bytes  # noqa
+            bytes(header).ljust((free_space_end), b"\0") + schema_record_bytes  # noqa
         ),
         schema_record=schema_record,
         size=page_size,

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -1,17 +1,50 @@
 from struct import pack
 
-from sandb.storage.slotted_page import Slot, SlottedPageHeader
+from sandb.storage.record import SchemaRecord
+from sandb.storage.slotted_page import Slot, SlottedPage, SlottedPageHeader
 
 
-def test_slotted_page_serialisation() -> None:
+def test_slotted_page_header_serialisation() -> None:
     slotted_page_header = SlottedPageHeader(
         page_id=0,
         free_space_start=28,
         free_space_end=32,
         slots=[Slot(record_id=0, record_pointer=33, record_length=4)],
-        records=[pack("<i", 84)],
     )
 
     assert slotted_page_header == SlottedPageHeader.from_bytes(
         slotted_page_header.to_bytes()
     )
+
+
+def test_slotted_page_add_record() -> None:
+    header = SlottedPageHeader(
+        page_id=0,
+        free_space_start=28,
+        free_space_end=99,
+        slots=[Slot(record_id=0, record_pointer=100, record_length=4)],
+        next_row_id=1,
+    )
+
+    schema_record = SchemaRecord(
+        0, "table_1", dtypes=[1, 0], col_names=["str_col", "int_col"]
+    )
+    schema_record_bytes = schema_record.to_bytes()
+
+    slotted_page = SlottedPage(
+        header=header,
+        byte_str=bytearray(
+            header.to_bytes().ljust((150 - len(schema_record_bytes)), b"\0")
+            + schema_record_bytes  # noqa
+        ),
+        schema_record=schema_record,
+        size=150,
+    )
+    slotted_page.add_record(pack("<3si", "abc".encode("utf-8"), 2))
+
+    updated_slotted_page = SlottedPage.from_bytes(bytes(slotted_page.byte_str))
+
+    assert updated_slotted_page.header.free_space_start == 40
+    assert updated_slotted_page.header.free_space_end == 92
+    assert updated_slotted_page.header.slots[1] == Slot(1, 93, 7)
+    assert updated_slotted_page.schema_record == schema_record

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -1,7 +1,13 @@
 from struct import pack
 
 from sandb.storage.record import SchemaRecord
-from sandb.storage.slotted_page import Slot, SlottedPage, SlottedPageHeader
+from sandb.storage.slotted_page import (
+    SLOT_SIZE,
+    SLOTTED_PAGE_HEADER_METADATA_SIZE,
+    Slot,
+    SlottedPage,
+    SlottedPageHeader,
+)
 
 
 def test_slotted_page_header_serialisation() -> None:
@@ -18,33 +24,49 @@ def test_slotted_page_header_serialisation() -> None:
 
 
 def test_slotted_page_add_record() -> None:
-    header = SlottedPageHeader(
-        page_id=0,
-        free_space_start=28,
-        free_space_end=101,
-        slots=[Slot(record_id=0, record_pointer=101, record_length=4)],
-        next_row_id=1,
-    )
-
+    page_size = 150
     schema_record = SchemaRecord(
         0, "table_1", dtypes=[1, 0], col_names=["str_col", "int_col"]
     )
     schema_record_bytes = schema_record.to_bytes()
+    free_space_end = page_size - len(schema_record_bytes)
+
+    header = SlottedPageHeader(
+        page_id=0,
+        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE,
+        free_space_end=free_space_end,
+        slots=[
+            Slot(
+                record_id=0,
+                record_pointer=free_space_end,
+                record_length=4,
+            )
+        ],
+        next_row_id=1,
+    )
 
     slotted_page = SlottedPage(
         header=header,
         byte_str=bytearray(
-            header.to_bytes().ljust((150 - len(schema_record_bytes)), b"\0")
+            header.to_bytes().ljust((free_space_end), b"\0")
             + schema_record_bytes  # noqa
         ),
         schema_record=schema_record,
-        size=150,
+        size=page_size,
     )
-    slotted_page.add_record(pack("<3si", "abc".encode("utf-8"), 2))
+    record_to_add = pack("<3si", "abc".encode("utf-8"), 2)
+    slotted_page.add_record(record_to_add)
 
     updated_slotted_page = SlottedPage.from_bytes(bytes(slotted_page.byte_str))
 
-    assert updated_slotted_page.header.free_space_start == 40
-    assert updated_slotted_page.header.free_space_end == 94
-    assert updated_slotted_page.header.slots[1] == Slot(1, 94, 7)
+    assert (
+        updated_slotted_page.header.free_space_start
+        == SLOTTED_PAGE_HEADER_METADATA_SIZE + 2 * SLOT_SIZE  # noqa
+    )
+    assert updated_slotted_page.header.free_space_end == page_size - len(
+        schema_record_bytes
+    ) - len(record_to_add)
+    assert updated_slotted_page.header.slots[1] == Slot(
+        1, page_size - len(schema_record_bytes) - len(record_to_add), len(record_to_add)
+    )
     assert updated_slotted_page.schema_record == schema_record

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -1,8 +1,5 @@
-from struct import pack
-
 import pytest
 
-from sandb.storage.record import SchemaRecord
 from sandb.storage.slotted_page import (
     SLOT_SIZE,
     SLOTTED_PAGE_HEADER_METADATA_SIZE,
@@ -27,39 +24,145 @@ def test_slotted_page_header_serialisation() -> None:
     )
 
 
-def test_slotted_page_add_record(schema_record: SchemaRecord) -> None:
-    page_size = 150
-    schema_record_bytes = bytes(schema_record)
+def test_add_record_successful(slotted_page_empty: SlottedPage) -> None:
+    """Test successful addition of a record to the slotted page."""
+    slotted_page = slotted_page_empty
+    record_data = b"test_record_data"
+    record_id = slotted_page.add_record(record_data)
 
-    header = SlottedPageHeader(
-        page_id=0,
-        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE,
-        free_space_end=page_size,
-        slots=[],
-        next_row_id=0,
-    )
-
-    slotted_page = SlottedPage(
-        header=header,
-        byte_str=bytearray(bytes(header).ljust((page_size), b"\0")),
-        size=page_size,
-    )
-    slotted_page.add_record(bytes(schema_record))
-    record_to_add = pack("<3si", "abc".encode("utf-8"), 2)
-    slotted_page.add_record(record_to_add)
-
-    updated_slotted_page = SlottedPage.from_bytes(bytes(slotted_page.byte_str))
-
+    assert record_id == 0
+    assert len(slotted_page.header.slots) == 1
+    slot = slotted_page.header.slots[0]
+    assert slot.record_id == 0
+    assert slot.record_length == len(record_data)
+    assert slot.record_pointer == slotted_page.size - len(record_data)
     assert (
-        updated_slotted_page.header.free_space_start
-        == SLOTTED_PAGE_HEADER_METADATA_SIZE + 2 * SLOT_SIZE  # noqa
+        slotted_page.header.free_space_start
+        == SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE
     )
-    assert updated_slotted_page.header.free_space_end == page_size - len(
-        schema_record_bytes
-    ) - len(record_to_add)
-    assert updated_slotted_page.header.slots[1] == Slot(
-        1, page_size - len(schema_record_bytes) - len(record_to_add), len(record_to_add)
+    assert slotted_page.header.free_space_end == slotted_page.size - len(record_data)
+    assert slotted_page.is_dirty is True
+    assert (
+        slotted_page.byte_str[
+            slot.record_pointer : slot.record_pointer + slot.record_length
+        ]
+        == record_data
     )
+
+
+def test_add_record_page_full(slotted_page_empty: SlottedPage) -> None:
+    """Test adding a record that exceeds the page's free space,
+    raising PageFullException."""
+    slotted_page = slotted_page_empty
+    page_size = slotted_page.size
+    header_size_with_initial_slot = SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE
+
+    max_record_size = page_size - header_size_with_initial_slot
+    record_data = b"A" * max_record_size
+
+    slotted_page.add_record(record_data)
+
+    record_data_too_large = b"TOO_LARGE"
+    with pytest.raises(PageFullException):
+        slotted_page.add_record(record_data_too_large)
+
+
+def test_add_record_multiple_records(slotted_page_empty: SlottedPage) -> None:
+    """Test adding multiple records to the slotted page."""
+    slotted_page = slotted_page_empty
+    record_data1 = b"record_1"
+    record_data2 = b"record_longer_2"
+    record_data3 = b"record_3"
+
+    record_id1 = slotted_page.add_record(record_data1)
+    record_id2 = slotted_page.add_record(record_data2)
+    record_id3 = slotted_page.add_record(record_data3)
+
+    assert record_id1 == 0
+    assert record_id2 == 1
+    assert record_id3 == 2
+    assert len(slotted_page.header.slots) == 3
+
+    slot3 = slotted_page.header.slots[2]
+    assert slot3.record_id == 2
+    assert slot3.record_length == len(record_data3)
+    assert slot3.record_pointer == slotted_page.size - len(record_data1) - len(
+        record_data2
+    ) - len(record_data3)
+
+    # Check free space pointers
+    expected_free_space_start = SLOTTED_PAGE_HEADER_METADATA_SIZE + 3 * SLOT_SIZE
+    expected_free_space_end = (
+        slotted_page.size - len(record_data1) - len(record_data2) - len(record_data3)
+    )
+    assert slotted_page.header.free_space_start == expected_free_space_start
+    assert slotted_page.header.free_space_end == expected_free_space_end
+    assert slotted_page.is_dirty is True
+    assert (
+        slotted_page.byte_str[
+            slot3.record_pointer : slot3.record_pointer + slot3.record_length
+        ]
+        == record_data3
+    )
+    assert slotted_page.header.next_row_id == 3
+
+
+def test_add_record_zero_length_record(slotted_page_empty: SlottedPage) -> None:
+    """Test adding a zero-length record."""
+    slotted_page = slotted_page_empty
+    record_data = b""
+    record_id = slotted_page.add_record(record_data)
+
+    assert record_id == 0
+    assert len(slotted_page.header.slots) == 1
+    slot = slotted_page.header.slots[0]
+    assert slot.record_id == 0
+    assert slot.record_length == 0
+    assert slot.record_pointer == slotted_page.size
+    assert (
+        slotted_page.header.free_space_start
+        == SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE
+    )
+    assert slotted_page.header.free_space_end == slotted_page.size
+    assert slotted_page.is_dirty is True
+
+
+def test_add_record_updates_header_bytes(slotted_page_empty: SlottedPage) -> None:
+    """Test that adding a record correctly updates the header bytes in byte_str."""
+    slotted_page = slotted_page_empty
+    initial_header_bytes = bytes(slotted_page.header)
+
+    record_data = b"test_record"
+    slotted_page.add_record(record_data)
+    updated_header_bytes = bytes(slotted_page.header)
+
+    assert updated_header_bytes != initial_header_bytes
+    deserialized_header = SlottedPageHeader.from_bytes(bytes(slotted_page.byte_str))
+    assert deserialized_header == slotted_page.header
+
+
+def test_add_record_exactly_fills_remaining_space(
+    slotted_page_empty: SlottedPage,
+) -> None:
+    """Test adding a record that exactly fills the remaining space on the page."""
+    slotted_page = slotted_page_empty
+    initial_free_space = (
+        slotted_page.header.free_space_end - slotted_page.header.free_space_start
+    )
+    record_size = initial_free_space - SLOT_SIZE
+
+    record_data = b"B" * record_size
+    record_id = slotted_page.add_record(record_data)
+
+    assert record_id == 0
+    assert len(slotted_page.header.slots) == 1
+    slot = slotted_page.header.slots[0]
+    assert slot.record_length == record_size
+    assert (
+        slotted_page.header.free_space_end
+        == SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE
+    )
+    assert slotted_page.header.free_space_start == slotted_page.header.free_space_end
 
 
 def test_delete_record_successful(slotted_page: SlottedPage) -> None:
@@ -79,7 +182,7 @@ def test_delete_record_successful(slotted_page: SlottedPage) -> None:
     assert deleted_slot is not None
     assert deleted_slot.record_pointer == 0
 
-    assert slotted_page.header.is_dirty
+    assert slotted_page.is_dirty
 
 
 def test_delete_record_not_found(slotted_page: SlottedPage) -> None:
@@ -111,7 +214,7 @@ def test_update_record_in_place_smaller(slotted_page: SlottedPage) -> None:
         == new_record_data
     )
 
-    assert slotted_page.header.is_dirty
+    assert slotted_page.is_dirty
     assert updated_record_id == original_slot.record_id
 
 
@@ -139,7 +242,7 @@ def test_update_record_in_place_same_size(slotted_page: SlottedPage) -> None:
         == new_record_data
     )
 
-    assert slotted_page.header.is_dirty
+    assert slotted_page.is_dirty
     assert updated_record_id == record_id_to_update
 
 
@@ -179,7 +282,7 @@ def test_update_record_relocation_larger_fits(slotted_page: SlottedPage) -> None
     assert original_slot_deleted is not None
     assert original_slot_deleted.record_pointer == 0
 
-    assert slotted_page.header.is_dirty
+    assert slotted_page.is_dirty
     assert updated_record_id != record_id_to_update
 
 

--- a/tests/unit/sandb/storage/test_slotted_page.py
+++ b/tests/unit/sandb/storage/test_slotted_page.py
@@ -1,9 +1,13 @@
 from struct import pack
 
+import pytest
+
 from sandb.storage.record import SchemaRecord
 from sandb.storage.slotted_page import (
     SLOT_SIZE,
     SLOTTED_PAGE_HEADER_METADATA_SIZE,
+    PageFullException,
+    RecordNotInPage,
     Slot,
     SlottedPage,
     SlottedPageHeader,
@@ -23,36 +27,24 @@ def test_slotted_page_header_serialisation() -> None:
     )
 
 
-def test_slotted_page_add_record() -> None:
+def test_slotted_page_add_record(schema_record: SchemaRecord) -> None:
     page_size = 150
-    schema_record = SchemaRecord(
-        0, "table_1", dtypes=[1, 0], col_names=["str_col", "int_col"]
-    )
     schema_record_bytes = bytes(schema_record)
-    free_space_end = page_size - len(schema_record_bytes)
 
     header = SlottedPageHeader(
         page_id=0,
-        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE + SLOT_SIZE,
-        free_space_end=free_space_end,
-        slots=[
-            Slot(
-                record_id=0,
-                record_pointer=free_space_end,
-                record_length=4,
-            )
-        ],
-        next_row_id=1,
+        free_space_start=SLOTTED_PAGE_HEADER_METADATA_SIZE,
+        free_space_end=page_size,
+        slots=[],
+        next_row_id=0,
     )
 
     slotted_page = SlottedPage(
         header=header,
-        byte_str=bytearray(
-            bytes(header).ljust((free_space_end), b"\0") + schema_record_bytes  # noqa
-        ),
-        schema_record=schema_record,
+        byte_str=bytearray(bytes(header).ljust((page_size), b"\0")),
         size=page_size,
     )
+    slotted_page.add_record(bytes(schema_record))
     record_to_add = pack("<3si", "abc".encode("utf-8"), 2)
     slotted_page.add_record(record_to_add)
 
@@ -68,4 +60,148 @@ def test_slotted_page_add_record() -> None:
     assert updated_slotted_page.header.slots[1] == Slot(
         1, page_size - len(schema_record_bytes) - len(record_to_add), len(record_to_add)
     )
-    assert updated_slotted_page.schema_record == schema_record
+
+
+def test_delete_record_successful(slotted_page: SlottedPage) -> None:
+    slotted_page = slotted_page
+    original_slot = slotted_page.header.slots[1]
+    record_id_to_delete = original_slot.record_id
+    slotted_page.delete(record_id_to_delete)
+
+    deleted_slot = next(
+        (
+            slot
+            for slot in slotted_page.header.slots
+            if slot.record_id == record_id_to_delete
+        ),
+        None,
+    )
+    assert deleted_slot is not None
+    assert deleted_slot.record_pointer == 0
+
+    assert slotted_page.header.is_dirty
+
+
+def test_delete_record_not_found(slotted_page: SlottedPage) -> None:
+    record_id_to_delete = 999
+    with pytest.raises(RecordNotInPage):
+        slotted_page.delete(record_id_to_delete)
+
+
+def test_update_record_in_place_smaller(slotted_page: SlottedPage) -> None:
+    original_slot = slotted_page.header.slots[2]
+
+    new_record_data = b"record_new"
+    updated_record_id = slotted_page.update(original_slot.record_id, new_record_data)
+
+    updated_slot = next(
+        (
+            slot
+            for slot in slotted_page.header.slots
+            if slot.record_id == original_slot.record_id
+        )
+    )
+    assert updated_slot.record_pointer == original_slot.record_pointer
+    assert updated_slot.record_length == len(new_record_data)
+    assert (
+        slotted_page.byte_str[
+            updated_slot.record_pointer : updated_slot.record_pointer
+            + updated_slot.record_length
+        ]
+        == new_record_data
+    )
+
+    assert slotted_page.header.is_dirty
+    assert updated_record_id == original_slot.record_id
+
+
+def test_update_record_in_place_same_size(slotted_page: SlottedPage) -> None:
+    original_slot = slotted_page.header.slots[3]
+    record_id_to_update = original_slot.record_id
+    original_pointer = original_slot.record_pointer
+
+    new_record_data = b"record_data_3"
+    updated_record_id = slotted_page.update(record_id_to_update, new_record_data)
+    updated_slot = next(
+        (
+            slot
+            for slot in slotted_page.header.slots
+            if slot.record_id == record_id_to_update
+        )
+    )
+    assert updated_slot.record_pointer == original_pointer
+    assert updated_slot.record_length == len(new_record_data)
+    assert (
+        slotted_page.byte_str[
+            updated_slot.record_pointer : updated_slot.record_pointer
+            + updated_slot.record_length
+        ]
+        == new_record_data
+    )
+
+    assert slotted_page.header.is_dirty
+    assert updated_record_id == record_id_to_update
+
+
+def test_update_record_relocation_larger_fits(slotted_page: SlottedPage) -> None:
+    original_slot = slotted_page.header.slots[1]
+    original_pointer = original_slot.record_pointer
+    record_id_to_update = original_slot.record_id
+
+    new_record_data = b"record_data_1_much_longer"
+    updated_record_id = slotted_page.update(record_id_to_update, new_record_data)
+
+    updated_slot = next(
+        (
+            slot
+            for slot in slotted_page.header.slots
+            if slot.record_id == updated_record_id
+        )
+    )
+    assert updated_slot.record_pointer != original_pointer
+    assert updated_slot.record_length == len(new_record_data)
+    assert (
+        slotted_page.byte_str[
+            updated_slot.record_pointer : updated_slot.record_pointer
+            + updated_slot.record_length
+        ]
+        == new_record_data
+    )
+
+    original_slot_deleted = next(
+        (
+            slot
+            for slot in slotted_page.header.slots
+            if slot.record_id == record_id_to_update
+        ),
+        None,
+    )
+    assert original_slot_deleted is not None
+    assert original_slot_deleted.record_pointer == 0
+
+    assert slotted_page.header.is_dirty
+    assert updated_record_id != record_id_to_update
+
+
+def test_update_record_relocation_larger_page_full() -> None:
+    page_almost_full_header = SlottedPageHeader(
+        page_id=2, free_space_start=4050, free_space_end=4096, slots=[]
+    )
+    page_almost_full = SlottedPage(
+        header=page_almost_full_header,
+        byte_str=bytearray(4096),
+    )
+    record_id_page_full = page_almost_full.add_record(b"initial_record")
+
+    record_id_to_update = record_id_page_full
+    new_record_data = b"much_larger_record_that_wont_fit"
+
+    with pytest.raises(PageFullException):
+        page_almost_full.update(record_id_to_update, new_record_data)
+
+
+def test_update_record_not_found(slotted_page: SlottedPage) -> None:
+    record_id_to_update = 999
+    new_record_data = b"new_data"
+    with pytest.raises(RecordNotInPage):
+        slotted_page.update(record_id_to_update, new_record_data)


### PR DESCRIPTION
Actually added in a SlottedPage class. 

So now we have a Slot class which is contained in the SlottedPageHeader class, which is in turn stored in the SlottedPage class.

Now everything should be managed by the slotted page. The slotted page contains the header, size of the page, byte str of the page and is dirty flag.

Now the header will be overwritten in the byte str on every update and is dirty_flag set to True. 

I have added an add_record, delete_record and update_record methods.

add_record: Will attempt to add a new record to the slotted page. First checks there is enough space, then updates the slots in the header and updates the byte_str with the updated header and record in the correct positions. 

delete_record: sets the record_pointer = 0 to mark a slot as deleted. At the momen does not reclaim space in the bytes tr just marks as deleted. 

update_record: If the new record + slot length is less than the empty space size we will update the record in place in the byte str. Else we will delete the old record and insert the new record. Or raise an error if the page is too full for the new record. 